### PR TITLE
Fixed parser regex for month field

### DIFF
--- a/src/models/parser.ts
+++ b/src/models/parser.ts
@@ -5,7 +5,7 @@ import { writeToFile, readFromFile } from "../utils";
 export class Parser {
   private fileName = "My Clippings.txt";
   private regex =
-    /(.+) \((.+)\)\r*\n- Your Highlight (at|on) (location|Location|page)( |(.+))([0-9]+)-([0-9]+) \| Added on ([a-zA-Z]+), ([a-zA-Z]+|[0-9]{2}) ([0-9]{2}|[a-zA-Z]+),? ([0-9]{4}) ([0-9]+):([0-9]+):([0-9]+\s? A?P?M?)\r*\n\r*\n(.+)/gm;
+    /(.+) \((.+)\)\r*\n- Your Highlight (at|on) (location|Location|page)( |(.+))([0-9]+)-([0-9]+) \| Added on ([a-zA-Z]+), ([a-zA-Z]+|[0-9]+) ([0-9]+|[a-zA-Z]+),? ([0-9]{4}) ([0-9]+):([0-9]+):([0-9]+\s? A?P?M?)\r*\n\r*\n(.+)/gm;
   private splitter = /=+\r*\n/gm;
   private nonUtf8 = /\uFEFF/gmu;
   private clippings: Clipping[] = [];


### PR DESCRIPTION
Hi there! First I wanted to thank you for an awesome app! I've been enjoying using it so far :)

I found the following bug:
The parser failed for the following input

Rip it up (Richard Wiseman)
- Your Highlight on Location 114-114 | Added on Monday, July 4, 2022 7:16:22 AM

test

Because the regex specifies [0-9]{2} for the Month field. The solution I suggest is to check against [0-9]+ instead.