### PR TITLE
fix(parser): update regex for page

### DIFF
--- a/src/models/parser.ts
+++ b/src/models/parser.ts
@@ -5,7 +5,7 @@ import { writeToFile, readFromFile } from "../utils";
 export class Parser {
   private fileName = "My Clippings.txt";
   private regex =
-    /(.+) \((.+)\)\r*\n- Your Highlight (at|on) (location|Location|page)( |(.+))([0-9]+)-([0-9]+) \| Added on ([a-zA-Z]+), ([a-zA-Z]+|[0-9]+) ([0-9]+|[a-zA-Z]+),? ([0-9]{4}) ([0-9]+):([0-9]+):([0-9]+\s? A?P?M?)\r*\n\r*\n(.+)/gm;
+    /(.+) \((.+)\)\r*\n- Your Highlight (at|on) (location|Location|page|Page)( |(.+))([0-9]+)-([0-9]+) \| Added on ([a-zA-Z]+), ([a-zA-Z]+|[0-9]+) ([0-9]+|[a-zA-Z]+),? ([0-9]{4}) ([0-9]+):([0-9]+):([0-9]+\s? A?P?M?)\r*\n\r*\n(.+)/gm;
   private splitter = /=+\r*\n/gm;
   private nonUtf8 = /\uFEFF/gmu;
   private clippings: Clipping[] = [];


### PR DESCRIPTION
Kindle 4 (Touch) with latest software was unable to sync with notion and this was because of the regex. Below is the example from MyClippings.txt. After this fix, the book was successfully synced with Notion.

```
Effective TypeScript (Dan Vanderkam)
- Your Highlight on Page 50 | Location 755-755 | Added on Saturday, February 11, 2023 12:13:20 PM

any types and type assertions (as any)
==========
Effective TypeScript (Dan Vanderkam)
- Your Highlight on Page 54 | Location 819-819 | Added on Saturday, February 11, 2023 12:19:12 PM

any types are often the source of these uncaught errors.
==========

```

`grouped-clippings.json`

```
[{"title":"Effective TypeScript","author":"Dan Vanderkam","highlights":["any types and type assertions (as any)","any types are often the source of these uncaught errors."]}]
```