### PR TITLE
Added Spanish Highlights format to the Regex rule

### DIFF
--- a/src/models/parser.ts
+++ b/src/models/parser.ts
@@ -5,7 +5,7 @@ import { writeToFile, readFromFile } from "../utils";
 export class Parser {
   private fileName = "My Clippings.txt";
   private regex =
-    /(.+) \((.+)\)\r*\n- Your Highlight (at|on) (location|Location|page|Page)( |(.+))([0-9]+)-([0-9]+) \| Added on ([a-zA-Z]+), ([a-zA-Z]+|[0-9]+) ([0-9]+|[a-zA-Z]+),? ([0-9]{4}) ([0-9]+):([0-9]+):([0-9]+\s? ?A?P?M?)\r*\n\r*\n(.+)/gm;
+    /(.+) \((.+)\)\r*\n- (Your Highlight|La subrayado) (at|on|en la) (location|Location|page|Page|posición)( |(.+))([0-9]+)-([0-9]+) \| (Added on|Añadido el) ([a-zA-Zà-üÀ-Ü]+), ([a-zA-Z]+|[0-9]+) (de ([a-zA-Zà-üÀ-Ü])+ de|[0-9]+|[a-zA-Z]+),? ([0-9]{4}) ([0-9]+):([0-9]+):([0-9]+\s? ?A?P?M?)\r*\n\r*\n(.+)/gm;
   private splitter = /=+\r*\n/gm;
   private nonUtf8 = /\uFEFF/gmu;
   private clippings: Clipping[] = [];


### PR DESCRIPTION
Hello! Thanks for this project, I added a bit of code to let parsing for Spanish books.

PD: I didn't check it running the docker, but I check it here: regexr.com/7egv4