### PR TITLE
Update parser.ts to also parse german clippings

### DIFF
--- a/src/models/parser.ts
+++ b/src/models/parser.ts
@@ -5,7 +5,7 @@ import { writeToFile, readFromFile, formatAuthorName } from "../utils";
 export class Parser {
   private fileName = "My Clippings.txt";
   private regex =
-    /(.+) \((.+)\)\r*\n- (?:Your Highlight|La subrayado|Your Note|\u60a8\u5728\u4f4d)(.+)\r*\n\r*\n(.+)/gm;
+    /(.+) \((.+)\)\r*\n- (?:Your Highlight|La subrayado|Your Note|Deine Markierung|\u60a8\u5728\u4f4d)(.+)\r*\n\r*\n(.+)/gm;
   private splitter = /=+\r*\n/gm;
   private nonUtf8 = /\uFEFF/gmu;
   private clippings: Clipping[] = [];


### PR DESCRIPTION
I've updated the parse-regex to also parse german clippings. Also tested it with own ghcr-image and adaptions to workflow.